### PR TITLE
Remove effects on installation (via `postinstall` script)

### DIFF
--- a/.changeset/yellow-ears-serve.md
+++ b/.changeset/yellow-ears-serve.md
@@ -1,0 +1,5 @@
+---
+'@as-integrations/koa': patch
+---
+
+Remove effectful install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,7 @@ jobs:
     steps:
       - setup-node:
           node-version: <<parameters.node-version>>
+      - run: npm run build
       - run: npm run test:ci
       - store_test_results:
           path: junit.xml

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "@as-integrations/koa",
       "version": "0.2.0",
-      "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {
         "@apollo/server": "4.0.5",

--- a/package.json
+++ b/package.json
@@ -25,11 +25,10 @@
     "node": ">=14.0"
   },
   "scripts": {
-    "//": "#use npx here to ensure that non-TS users triggering the postinstall script don't need to install TypeScript globally or in their project",
-    "build": "npx -p typescript tsc --build tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "clean": "git clean -dfqX",
     "install-with-npm-8.5": "npm i -g npm@^8.5.0 && npm i",
-    "postinstall": "npm run build",
+    "prepack": "npm run build",
     "prettier-check": "prettier --check .",
     "prettier-fix": "prettier --write .",
     "publish-changeset": "changeset publish",


### PR DESCRIPTION
The `postinstall` hook provides a minor convenience for developers cloning the repo and developing within it, but only as far as running the build for you whenever you install. The drawback to using `postinstall` is that compilation runs whenever this package is installed into another repo, which is totally unnecessary and often (for JS users) results in failures when tsc or types packages aren't installed within the project.

Related:
https://github.com/apollographql/typescript-repo-template/pull/84
https://github.com/apollographql/typescript-repo-template/pull/92

Fixes #40