### PR TITLE
Drop support for Node.js v14

### DIFF
--- a/.changeset/weak-days-accept.md
+++ b/.changeset/weak-days-accept.md
@@ -1,0 +1,7 @@
+---
+'@as-integrations/koa': major
+---
+
+Drop support for Node.js 14, require v16+
+
+The only change required for users to take this update is to upgrade their Node.js version to v16+. No other breaking changes.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,9 +92,9 @@ workflows:
           matrix:
             parameters:
               node-version:
-                - "14"
                 - "16"
                 - "18"
+                - "20"
       - Full incremental delivery tests with graphql-js 17 canary
       - Prettier
       - Lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@types/koa": "2.13.6",
         "@types/koa__cors": "4.0.0",
         "@types/koa-bodyparser": "4.3.10",
-        "@types/node": "14.18.42",
+        "@types/node": "16.18.25",
         "@types/supertest": "2.0.12",
         "@typescript-eslint/eslint-plugin": "5.59.0",
         "@typescript-eslint/parser": "5.59.0",
@@ -37,7 +37,7 @@
         "typescript": "5.0.4"
       },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=16.0"
       },
       "peerDependencies": {
         "@apollo/server": "^4.0.0",
@@ -2837,9 +2837,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "14.18.42",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.42.tgz",
-      "integrity": "sha512-xefu+RBie4xWlK8hwAzGh3npDz/4VhF6icY/shU+zv/1fNn+ZVG7T7CRwe9LId9sAYRPxI+59QBPuKL3WpyGRg==",
+      "version": "16.18.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.25.tgz",
+      "integrity": "sha512-rUDO6s9Q/El1R1I21HG4qw/LstTHCPO/oQNAwI/4b2f9EWvMnqt4d3HJwPMawfZ3UvodB8516Yg+VAq54YM+eA==",
       "dev": true
     },
     "node_modules/@types/node-fetch": {
@@ -11965,9 +11965,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.18.42",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.42.tgz",
-      "integrity": "sha512-xefu+RBie4xWlK8hwAzGh3npDz/4VhF6icY/shU+zv/1fNn+ZVG7T7CRwe9LId9sAYRPxI+59QBPuKL3WpyGRg==",
+      "version": "16.18.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.25.tgz",
+      "integrity": "sha512-rUDO6s9Q/El1R1I21HG4qw/LstTHCPO/oQNAwI/4b2f9EWvMnqt4d3HJwPMawfZ3UvodB8516Yg+VAq54YM+eA==",
       "dev": true
     },
     "@types/node-fetch": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=14.0"
+    "node": ">=16.0"
   },
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
@@ -46,9 +46,9 @@
     "@koa/cors": "4.0.0",
     "@types/jest": "29.5.1",
     "@types/koa": "2.13.6",
-    "@types/koa-bodyparser": "4.3.10",
     "@types/koa__cors": "4.0.0",
-    "@types/node": "14.18.42",
+    "@types/koa-bodyparser": "4.3.10",
+    "@types/node": "16.18.25",
     "@types/supertest": "2.0.12",
     "@typescript-eslint/eslint-plugin": "5.59.0",
     "@typescript-eslint/parser": "5.59.0",

--- a/renovate.json5
+++ b/renovate.json5
@@ -15,7 +15,7 @@
     // versions we support.
     {
       "matchPackageNames": ["@types/node"],
-      "allowedVersions": "14.x"
+      "allowedVersions": "16.x"
     },
   ],
 }


### PR DESCRIPTION
* engines.node >= 16
* Update @types/node and renovate config
* Stop testing v14, start testing v20