### PR TITLE
Parameterize the `Middleware` type

### DIFF
--- a/.changeset/strong-gifts-explain.md
+++ b/.changeset/strong-gifts-explain.md
@@ -1,0 +1,34 @@
+---
+'@as-integrations/koa': minor
+---
+
+Parameterize the returned Middleware type so that this library can be used along with a context-parameterized Koa app.
+
+In order to utilize this feature, provide your Koa app's `State` and `Context` types as type arguments to the `koaMiddleware` function.
+
+If you use a `context` function (for Apollo Server), the `State` and `Context` types are positions 1 and 2 like so:
+
+```ts
+type KoaState = { state: object };
+type KoaContext = { context: object };
+
+koaMiddleware<GraphQLContext, KoaState, KoaContext>(
+  new ApolloServer<GraphQLContext>(),
+  //...
+  {
+    context: async ({ ctx }) => ({ graphqlContext: {} }),
+  },
+);
+```
+
+If you don't use a `context` function, the `State` and `Context` types are positions 0 and 1 like so:
+
+```ts
+type KoaState = { state: object };
+type KoaContext = { context: object };
+
+koaMiddleware<KoaState, KoaContext>(
+  new ApolloServer<GraphQLContext>(),
+  //...
+);
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,15 +22,26 @@ interface KoaMiddlewareOptions<TContext extends BaseContext> {
   context?: ContextFunction<[KoaContextFunctionArgument], TContext>;
 }
 
-export function koaMiddleware<StateT = Koa.DefaultState, ContextT = Koa.DefaultContext>(
+export function koaMiddleware<
+  StateT = Koa.DefaultState,
+  ContextT = Koa.DefaultContext,
+>(
   server: ApolloServer<BaseContext>,
   options?: KoaMiddlewareOptions<BaseContext>,
 ): Koa.Middleware<StateT, ContextT>;
-export function koaMiddleware<TContext extends BaseContext, StateT = Koa.DefaultState, ContextT = Koa.DefaultContext>(
+export function koaMiddleware<
+  TContext extends BaseContext,
+  StateT = Koa.DefaultState,
+  ContextT = Koa.DefaultContext,
+>(
   server: ApolloServer<TContext>,
   options: WithRequired<KoaMiddlewareOptions<TContext>, 'context'>,
 ): Koa.Middleware<StateT, ContextT>;
-export function koaMiddleware<TContext extends BaseContext, StateT = Koa.DefaultState, ContextT = Koa.DefaultContext>(
+export function koaMiddleware<
+  TContext extends BaseContext,
+  StateT = Koa.DefaultState,
+  ContextT = Koa.DefaultContext,
+>(
   server: ApolloServer<TContext>,
   options?: KoaMiddlewareOptions<TContext>,
 ): Koa.Middleware<StateT, ContextT> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,18 +22,18 @@ interface KoaMiddlewareOptions<TContext extends BaseContext> {
   context?: ContextFunction<[KoaContextFunctionArgument], TContext>;
 }
 
-export function koaMiddleware(
+export function koaMiddleware<StateT = Koa.DefaultState, ContextT = Koa.DefaultContext>(
   server: ApolloServer<BaseContext>,
   options?: KoaMiddlewareOptions<BaseContext>,
-): Koa.Middleware;
-export function koaMiddleware<TContext extends BaseContext>(
+): Koa.Middleware<StateT, ContextT>;
+export function koaMiddleware<TContext extends BaseContext, StateT = Koa.DefaultState, ContextT = Koa.DefaultContext>(
   server: ApolloServer<TContext>,
   options: WithRequired<KoaMiddlewareOptions<TContext>, 'context'>,
-): Koa.Middleware;
-export function koaMiddleware<TContext extends BaseContext>(
+): Koa.Middleware<StateT, ContextT>;
+export function koaMiddleware<TContext extends BaseContext, StateT = Koa.DefaultState, ContextT = Koa.DefaultContext>(
   server: ApolloServer<TContext>,
   options?: KoaMiddlewareOptions<TContext>,
-): Koa.Middleware {
+): Koa.Middleware<StateT, ContextT> {
   server.assertStarted('koaMiddleware()');
 
   // This `any` is safe because the overload above shows that context can


### PR DESCRIPTION
Parameterize the returned `Middleware` type so that this library can be used along with a context-parameterized Koa app.

ref. https://github.com/DefinitelyTyped/DefinitelyTyped/pull/31704