### PR TITLE
Parameterize `KoaContextFunctionArgument` and `KoaMiddlewareOptions`

### DIFF
--- a/.changeset/empty-walls-retire.md
+++ b/.changeset/empty-walls-retire.md
@@ -1,0 +1,5 @@
+---
+'@as-integrations/koa': patch
+---
+
+Parameterize `KoaContextFunctionArgument` and `KoaMiddlewareOptions` so that the `ctx` parameter in the `context` function is correctly typed when this library is used along with a context-parameterized Koa app.


### PR DESCRIPTION
Thanks to #130, the middleware now can be `use()`'d in a context-parameterized Koa app.

I've noticed, however, that it is still impossible to derive a GraphQL context from a Koa context in a type-safe manner, as the `ctx` parameter of the `context` functions is still unparameterized.
(i.e., `ctx: Koa.Context` instead of `ctx: Koa.ParameterizedContext<StateT, ContextT>`).