### PR TITLE
fix: call middlewares defined after koaMiddleware

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ export function koaMiddleware<
     TContext
   > = options?.context ?? defaultContext;
 
-  return async (ctx) => {
+  return async (ctx, next) => {
     if (!ctx.request.body) {
       // The json koa-bodyparser *always* sets ctx.request.body to {} if it's unset (even
       // if the Content-Type doesn't match), so if it isn't set, you probably
@@ -136,5 +136,7 @@ export function koaMiddleware<
     for (const [key, value] of headers) {
       ctx.set(key, value);
     }
+
+    return next();
   };
 }


### PR DESCRIPTION
Not having the `next` function call can cause unexpected issues on the user's codebase, like on Strapi, it prevented the authentication hook from being called if declared after this middleware.

See https://github.com/strapi/strapi/pull/21977