### PR TITLE
adjustments to npm publish workflow for OIDC publishing

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -9,6 +9,10 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -16,10 +20,10 @@ jobs:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
-      - name: Setup Node.js 16.x
+      - name: Setup Node.js 24.x
         uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 24.x
 
       - name: Install Dependencies
         run: npm i
@@ -30,4 +34,4 @@ jobs:
           publish: npm run publish-changeset
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ""

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/apollo-server-integrations/apollo-server-integration-koa"
+    "url": "git+https://github.com/apollo-server-integrations/apollo-server-integration-koa.git"
   },
   "keywords": [
     "GraphQL",


### PR DESCRIPTION
This PR makes changes to enable OIDC publishing to npm, so that we no longer need to use npm tokens stored in GitHub secrets.

It makes the following changes:
 * Update the `repository` field in `package.json` files to the format that `npm` expects here - via `npm pkg fix`
 * Add permissions required for OIDC publishing to the GitHub Actions workflow
 * Ensures that the node version for publishing is node 24. `npm` versions shipping with older node versions cannot publish via OIDC. Some node 22 versions can, but it's a gamble and hard to debug if something goes wrong.
 * Remove references to `NPM_TOKEN` secrets in the GitHub Actions workflow - or if using changesets, sets it to `""` as changesets requires the env var to be set, but actually doesn't do anything - and it should be empty for OIDC publishing to work.
 
 I have already gone ahead and set OIDC publishing on the npm side, so this is just the second half of the puzzle.